### PR TITLE
AN-5112/capybara-lp-swap

### DIFF
--- a/models/doc_descriptions/dex/complete_dex_swap_docs.md
+++ b/models/doc_descriptions/dex/complete_dex_swap_docs.md
@@ -1,6 +1,6 @@
 {% docs ez_dex_swaps_table_doc %}
 
-This table currently contains swap events from the ```fact_event_logs``` table for DRAGONSWAP, KAIASWAP, KLAYSWAP, AND NEOPIN. along with other helpful columns including an amount USD where possible.
+This table currently contains swap events from the ```fact_event_logs``` table for DRAGONSWAP, KAIASWAP, KLAYSWAP, NEOPIN, and CAPYBARA. along with other helpful columns including an amount USD where possible.
 Note: A rule has been put in place to null out the amount_USD if that number is too divergent between amount_in_USD and amount_out_usd. This can happen for swaps of less liquid tokens during very high fluctuation of price.
 
 {% enddocs %}

--- a/models/gold/defi/defi__ez_dex_swaps.sql
+++ b/models/gold/defi/defi__ez_dex_swaps.sql
@@ -5,7 +5,7 @@
     meta={
         'database_tags':{
             'table': {
-                'PROTOCOL': 'DRAGONSWAP, KAIASWAP, KLAYSWAP, NEOPIN',
+                'PROTOCOL': 'DRAGONSWAP, KAIASWAP, KLAYSWAP, NEOPIN, CAPYBARA', 
                 'PURPOSE': 'DEX, SWAPS'
             }
         }

--- a/models/silver/defi/dex/capybara/silver_dex__capybara_pools.sql
+++ b/models/silver/defi/dex/capybara/silver_dex__capybara_pools.sql
@@ -1,0 +1,50 @@
+{{ config(
+    materialized = 'incremental',
+    incremental_strategy = 'delete+insert',
+    unique_key = 'pool_address',
+    tags = ['curated']
+) }}
+
+WITH contract_deployments AS (
+
+    SELECT
+        tx_hash,
+        block_number,
+        block_timestamp,
+        from_address AS deployer_address,
+        to_address AS contract_address,
+        _inserted_timestamp
+    FROM
+        {{ ref('silver__traces') }}
+    WHERE
+        from_address = '0x5280c2d41dbbb9e17664a6c560194d99f329bbb6'
+        AND to_address NOT IN (
+            '0x84f8cb916eb8aa6b9ba676ac38db26fb111e524b',
+            '0x442f2c12bd436cfdc736170274287cd70c5b6ab5'
+        ) -- Exclude testAsset
+        AND TYPE ILIKE 'create%'
+        AND tx_status = TRUE
+        AND trace_status = TRUE
+
+{% if is_incremental() %}
+AND _inserted_timestamp >= (
+    SELECT
+        MAX(_inserted_timestamp) - INTERVAL '12 hours'
+    FROM
+        {{ this }}
+)
+{% endif %}
+
+qualify(ROW_NUMBER() over(PARTITION BY to_address
+ORDER BY
+    block_timestamp ASC)) = 1
+)
+SELECT
+    tx_hash,
+    block_number,
+    block_timestamp,
+    deployer_address,
+    contract_address AS pool_address,
+    _inserted_timestamp
+FROM
+    contract_deployments

--- a/models/silver/defi/dex/capybara/silver_dex__capybara_pools.sql
+++ b/models/silver/defi/dex/capybara/silver_dex__capybara_pools.sql
@@ -23,8 +23,8 @@ WITH contract_deployments AS (
             '0x442f2c12bd436cfdc736170274287cd70c5b6ab5'
         ) -- Exclude testAsset
         AND TYPE ILIKE 'create%'
-        AND tx_status = TRUE
-        AND trace_status = TRUE
+        AND tx_status
+        AND trace_status
 
 {% if is_incremental() %}
 AND _inserted_timestamp >= (

--- a/models/silver/defi/dex/capybara/silver_dex__capybara_pools.yml
+++ b/models/silver/defi/dex/capybara/silver_dex__capybara_pools.yml
@@ -1,0 +1,11 @@
+version: 2
+models:
+  - name: silver_dex__capybara_pools
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - POOL_ADDRESS
+    columns:
+      - name: POOL_ADDRESS
+        tests:
+          - not_null

--- a/models/silver/defi/dex/capybara/silver_dex__capybara_swaps.sql
+++ b/models/silver/defi/dex/capybara/silver_dex__capybara_swaps.sql
@@ -61,7 +61,7 @@ swaps_base AS (
         ON l.contract_address = p.pool_address
     WHERE
         topics [0] :: STRING = '0x7fa01e8d24e5a6ec56e00b4ff8ee7ed97e7650a7846ec494bbaa5d65f1be9ea4'
-        AND tx_status = TRUE
+        AND tx_status
 
 {% if is_incremental() %}
 AND _inserted_timestamp >= (

--- a/models/silver/defi/dex/capybara/silver_dex__capybara_swaps.sql
+++ b/models/silver/defi/dex/capybara/silver_dex__capybara_swaps.sql
@@ -1,0 +1,95 @@
+{{ config(
+    materialized = 'incremental',
+    incremental_strategy = 'delete+insert',
+    unique_key = 'block_number',
+    cluster_by = ['block_timestamp::DATE'],
+    tags = ['curated','reorg']
+) }}
+
+WITH pools AS (
+
+    SELECT
+        pool_address
+    FROM
+        {{ ref('silver_dex__capybara_pools') }}
+),
+swaps_base AS (
+    SELECT
+        l.block_number,
+        l.block_timestamp,
+        l.tx_hash,
+        origin_function_signature,
+        origin_from_address,
+        origin_to_address,
+        l.event_index,
+        l.contract_address,
+        regexp_substr_all(SUBSTR(l.data, 3, len(l.data)), '.{64}') AS l_segmented_data,
+        CONCAT('0x', SUBSTR(l.topics [1] :: STRING, 27, 40)) AS sender_address,
+        CONCAT('0x', SUBSTR(l.topics [2] :: STRING, 27, 40)) AS to_address,
+        CONCAT(
+            '0x',
+            SUBSTR(
+                l_segmented_data [0] :: STRING,
+                25,
+                40
+            )
+        ) AS fromToken,
+        CONCAT(
+            '0x',
+            SUBSTR(
+                l_segmented_data [1] :: STRING,
+                25,
+                40
+            )
+        ) AS toToken,
+        TRY_TO_NUMBER(
+            utils.udf_hex_to_int(
+                l_segmented_data [2] :: STRING
+            )
+        ) AS fromAmount,
+        TRY_TO_NUMBER(
+            utils.udf_hex_to_int(
+                l_segmented_data [3] :: STRING
+            )
+        ) AS toAmount,
+        l._log_id,
+        l._inserted_timestamp
+    FROM
+        {{ ref('silver__logs') }}
+        l
+        INNER JOIN pools p
+        ON l.contract_address = p.pool_address
+    WHERE
+        topics [0] :: STRING = '0x7fa01e8d24e5a6ec56e00b4ff8ee7ed97e7650a7846ec494bbaa5d65f1be9ea4'
+        AND tx_status = TRUE
+
+{% if is_incremental() %}
+AND _inserted_timestamp >= (
+    SELECT
+        MAX(_inserted_timestamp) - INTERVAL '12 hours'
+    FROM
+        {{ this }}
+)
+{% endif %}
+)
+SELECT
+    block_number,
+    block_timestamp,
+    tx_hash,
+    origin_function_signature,
+    origin_from_address,
+    origin_to_address,
+    event_index,
+    contract_address,
+    sender_address AS sender,
+    to_address AS tx_to,
+    fromToken AS token_in,
+    toToken AS token_out,
+    fromAmount AS amount_in_unadj,
+    toAmount AS amount_out_unadj,
+    'Swap' AS event_name,
+    'capybara' AS platform,
+    _log_id,
+    _inserted_timestamp
+FROM
+    swaps_base

--- a/models/silver/defi/dex/capybara/silver_dex__capybara_swaps.yml
+++ b/models/silver/defi/dex/capybara/silver_dex__capybara_swaps.yml
@@ -1,0 +1,80 @@
+version: 2
+models:
+  - name: silver_dex__capybara_swaps
+   
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - _LOG_ID
+    columns:
+      - name: BLOCK_NUMBER
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - NUMBER
+                - FLOAT
+      - name: BLOCK_TIMESTAMP
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - TIMESTAMP_NTZ
+      - name: TX_HASH
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_match_regex:
+              regex: 0[xX][0-9a-fA-F]+
+      - name: CONTRACT_ADDRESS
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_match_regex:
+              regex: 0[xX][0-9a-fA-F]+
+      - name: TOKEN_IN
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_match_regex:
+              regex: 0[xX][0-9a-fA-F]+
+      - name: TOKEN_OUT
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_match_regex:
+              regex: 0[xX][0-9a-fA-F]+
+      - name: SENDER
+        tests:
+          - not_null:
+              where: BLOCK_TIMESTAMP > '2021-08-01'
+          - dbt_expectations.expect_column_values_to_match_regex:
+              regex: 0[xX][0-9a-fA-F]+
+      - name: TX_TO
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_match_regex:
+              regex: 0[xX][0-9a-fA-F]+
+      - name: PLATFORM
+        tests:
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - STRING
+                - VARCHAR
+      - name: EVENT_INDEX
+        tests:
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list:
+                - NUMBER
+                - FLOAT
+      - name: _LOG_ID
+        tests:
+          - not_null
+      - name: ORIGIN_FUNCTION_SIGNATURE
+        tests:
+          - not_null
+      - name: ORIGIN_FROM_ADDRESS
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_values_to_match_regex:
+              regex: 0[xX][0-9a-fA-F]+
+      - name: ORIGIN_TO_ADDRESS
+        tests:
+          - dbt_expectations.expect_column_values_to_match_regex:
+              regex: 0[xX][0-9a-fA-F]+


### PR DESCRIPTION
1. Adds capybara single-asset LP pools and dex swaps models
2. Pulls capybara swaps through to complete
3. Requires: 
`dbt run -m models/silver/defi/dex/capybara --full-refresh && dbt run -m models/silver/defi/dex/silver_dex__complete_dex_swaps.sql --vars '{"HEAL_MODELS":"capybara"}'`